### PR TITLE
Missing verification caused index out of bounds

### DIFF
--- a/autoload/phpcd.vim
+++ b/autoload/phpcd.vim
@@ -903,8 +903,10 @@ function! phpcd#GetClassName(start_line, context, current_namespace, imports) " 
 			if line =~? '^\s*' . object . '\s*=.*);\?$' " {{{
 				let classname = phpcd#GetCallChainReturnTypeAt(a:start_line - i)
 				let classname_parts = split(classname, '\\\+')
-				let classname_candidate = classname_parts[-1]
-				let class_candidate_namespace = join(classname_parts[0:-2], '\')
+				if len(classname_parts) > 0
+					let classname_candidate = classname_parts[-1]
+					let class_candidate_namespace = join(classname_parts[0:-2], '\')
+				endif
 				break
 			endif " }}}
 


### PR DESCRIPTION
I was having an index out of bounds error pointing to this line `let classname_candidate = classname_parts[-1]` looking at the code the same check that is made in the other places the same code is used is missing. I am a real noob in VimL but I think this makes sense and I also tested it for some time and everything seems fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/php-vim/phpcd.vim/71)
<!-- Reviewable:end -->
