### PR TITLE
uncomment deoplete source input pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ let g:deoplete#ignore_sources.php = ['omni']
 ```
 The phpcd will work with deoplete happily.
 
+However if you are experiencing problems with deoplete you can disable the phpcd source.
+
+```viml
+let g:deoplete#ignore_sources = get(g:, 'deoplete#ignore_sources', {})
+let g:deoplete#ignore_sources.php = ['phpcd', 'omni']
+```
+
 ## Usage
 
 ~~First, in the project directory, run `composer install` to install all the dependent packages and generate the autoload file.~~

--- a/rplugin/python3/deoplete/sources/phpcd.py
+++ b/rplugin/python3/deoplete/sources/phpcd.py
@@ -8,7 +8,7 @@ class Source(Base):
         self.mark = '[php]'
         self.filetypes = ['php']
         self.is_bytepos = True
-        # self.input_pattern = '\w+|[^. \t]->\w*|\w+::\w*'
+        self.input_pattern = '\w+|[^. \t]->\w*|\w+::\w*'
         self.rank = 500
         self.max_pattern_length = -1
         self.matchers = ['matcher_full_fuzzy']


### PR DESCRIPTION
Deoplete source input pattern was commented which cause the completion not to trigger.

This caused the necessity to manually configure an omni pattern for deoplete.