### PR TITLE
add extra method info for 'preview'

### DIFF
--- a/php/PHPCD.php
+++ b/php/PHPCD.php
@@ -734,7 +734,71 @@ class PHPCD implements RpcHandler
         ];
     }
 
-    private function getMethodInfo($method, $pattern = null)
+      /**
+     * @param \ReflectionParameter $param
+     * @return string
+     */
+    private function formatParamInfo(\ReflectionParameter $param)
+    {
+        /* @var ReflectionClass|null $hintedClass */
+        $hintedClass = $param->getClass();
+        $paramString = '';
+        if ($hintedClass) {
+            $paramString .= $hintedClass->getName() . ' ';
+        } elseif ($param->hasType()) {
+            $paramString .= $param->getType() . ' ';
+        }
+        $paramString .= '$' . $param->getName();
+        if (!$param->isDefaultValueAvailable()) {
+            return $paramString;
+        }
+        if ($param->isDefaultValueConstant()) {
+            $default = $param->getDefaultValueConstantName();
+        } else {
+            $default = $param->getDefaultValue();
+            if (is_string($default)) {
+                $default = "'$default'";
+            }
+        }
+        $paramString .= " = " . $default;
+        return $paramString;
+    }
+    /**
+     * @param \ReflectionMethod $param
+     * @return string
+     */
+    private function getExtraMethodInfo(\ReflectionMethod $method)
+    {
+        $name = $method->getName();
+        $declaringClass = $method->getDeclaringClass()->getName();
+        $visibility  = $method->isPrivate()   ? 'private'
+                     : $method->isProtected() ? 'protected'
+                     : 'public';
+        $accessMode = $method->isStatic() ? "::" : "->";
+        $paramsInfo = [];
+        foreach ($method->getParameters() as $param) {
+            $paramsInfo[] = $this->formatParamInfo($param);
+        }
+        $returnType = '';
+        if (method_exists($method, 'getReturnType') && $method->hasReturnType()) {
+            $returnType = " : " . (string)$method->getReturnType();
+        }
+        $docblock = preg_replace('/\n[\s]*\*/', "\n *", $method->getDocComment());
+        return sprintf(
+            "%s %s%s%s(\n%s)%s\n%s",
+            $visibility,
+            $name,
+            $accessMode,
+            $declaringClass,
+            count($paramsInfo)
+                ? '    ' . join(",\n    ", $paramsInfo) . "\n"
+                : '',
+            $returnType,
+            $docblock
+        );
+    }
+
+    private function getMethodInfo(\ReflectionMethod $method, $pattern = null)
     {
         $name = $method->getName();
         if ($pattern && !$this->matchPattern($pattern, $name)) {
@@ -750,7 +814,7 @@ class PHPCD implements RpcHandler
         return [
             'word' => $name,
             'abbr' => sprintf("%3s %s (%s)", $modifier, $name, join(', ', $params)),
-            'info' => $this->clearDoc($method->getDocComment()),
+            'info' => $this->getExtraMethodInfo($method),
             'kind' => 'f',
             'icase' => 1,
         ];

--- a/php/PHPCD.php
+++ b/php/PHPCD.php
@@ -787,9 +787,9 @@ class PHPCD implements RpcHandler
         return sprintf(
             "%s %s%s%s(\n%s)%s\n%s",
             $visibility,
-            $name,
-            $accessMode,
             $declaringClass,
+            $accessMode,
+            $name,
             count($paramsInfo)
                 ? '    ' . join(",\n    ", $paramsInfo) . "\n"
                 : '',


### PR DESCRIPTION
This adds extra information for scratch/preview.

**note:** PHP 5.4.3 or newer required for some of the reflection methods (param default value constant) This shouldn't be an issue as 5.6 is the oldest supported PHP version

requires the config setting "completeopt += preview"
example: `set completeopt=longest,menuone,preview`

**preview**
```
public MyNamespace\MyClass->someMethod(
    SomeNamespace\SomeClass $someClass,
    $foo = 'bar'
) : AnotherNamespace\ReturnTypehint

/**
 * Docblock here
 */
```