### PR TITLE
Fixed an undefined variable being used.

### DIFF
--- a/php/PHPID.php
+++ b/php/PHPID.php
@@ -39,7 +39,7 @@ class PHPID implements RpcHandler
     {
         list($parent, $interfaces) = $this->getClassInfo($class_name);
 
-        $this->_update($class_name, $parent, $interface);
+        $this->_update($class_name, $parent, $interfaces);
     }
 
     private function _update($class_name, $parent, $interfaces)


### PR DESCRIPTION
I noticed phpcd was behaving a bit odd, so I checked the log, and found an error about this undefined variable being used. I fixed the typo causing the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lvht/phpcd.vim/88)
<!-- Reviewable:end -->
