### PR TITLE
add Laravel/framework support, both normal and facades

### DIFF
--- a/php/PHPCD.php
+++ b/php/PHPCD.php
@@ -1066,7 +1066,7 @@ class PHPCD implements RpcHandler
                         'Mail' => 'Illuminate\Mail\Mailer',
                         'Notification' => 'Illuminate\Notifications\ChannelManager',
                         'Password' => 'Illuminate\Auth\Passwords\PasswordBrokerManager',
-                        'Queue ' => 'Illuminate\Queue\Queue',
+                        'Queue' => 'Illuminate\Queue\Queue',
                         'Redirect' => 'Illuminate\Routing\Redirector',
                         'Redis' => 'Illuminate\Redis\Database',
                         'Request' => 'Illuminate\Http\Request',

--- a/php/PHPCD.php
+++ b/php/PHPCD.php
@@ -1045,7 +1045,8 @@ class PHPCD implements RpcHandler
                 // 增加 facades 支持
                 if(file_exists($this->root.'/config/app.php')) {
                     $config = require_once($this->root.'/config/app.php');
-                    $aliases = $config['aliases'];
+                    $aliases = isset($config['aliases']) ? $config['aliases'] : [];
+                    if(!is_array($aliases)) $aliases = [];
                     $require = [
                         'App' => 'Illuminate\Foundation\Application',
                         'Artisan' => 'Illuminate\Contracts\Console\Kernel',
@@ -1066,7 +1067,7 @@ class PHPCD implements RpcHandler
                         'Mail' => 'Illuminate\Mail\Mailer',
                         'Notification' => 'Illuminate\Notifications\ChannelManager',
                         'Password' => 'Illuminate\Auth\Passwords\PasswordBrokerManager',
-                        'Queue' => 'Illuminate\Queue\Queue',
+                        'Queue' => 'Illuminate\Queue\Capsule\Manager',
                         'Redirect' => 'Illuminate\Routing\Redirector',
                         'Redis' => 'Illuminate\Redis\Database',
                         'Request' => 'Illuminate\Http\Request',

--- a/php/PHPCD.php
+++ b/php/PHPCD.php
@@ -1056,7 +1056,7 @@ class PHPCD implements RpcHandler
                         'Config' => 'Illuminate\Config\Repository',
                         'Cookie' => 'Illuminate\Cookie\CookieJar',
                         'Crypt' => 'Illuminate\Encryption\Encrypter',
-                        'DB' => 'Illuminate\Database\Connection',
+                        'DB' => 'Illuminate\Database\Capsule\Manager',
                         'Event' => 'Illuminate\Events\Dispatcher',
                         'File' => 'Illuminate\Filesystem\Filesystem',
                         'Gate' => 'Illuminate\Contracts\Auth\Access\Gate',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6964962/30443846-8b5cfad2-99b3-11e7-8bcd-92f296df8c6f.png)
![image](https://user-images.githubusercontent.com/6964962/30443858-9caa8e94-99b3-11e7-9e0c-a00c0b6cab3c.png)
![image](https://user-images.githubusercontent.com/6964962/30443874-aaf67a62-99b3-11e7-8787-0c2f4d0bc45b.png)

normally, phpcd will return [facadesAccessor, __call...] method list, and it's not helpful completion.
this pull request is to solve this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lvht/phpcd.vim/105)
<!-- Reviewable:end -->
