### PR TITLE
Optionally perform initialization on BufEnter

### DIFF
--- a/ftplugin/php_phpcd.vim
+++ b/ftplugin/php_phpcd.vim
@@ -14,43 +14,8 @@ silent! nnoremap <silent> <unique> <buffer> <C-t>
 
 command! -nargs=0 PHPID call phpcd#Index()
 
-if has('nvim')
-	let messenger = 'msgpack'
-else
-	let messenger = 'json'
-end
-
-function! Init() " {{{
-	let g:phpcd_root = phpcd#GetRoot()
-	let phpcd_vim = g:phpcd_root.'/.phpcd.vim'
-	if filereadable(phpcd_vim)
-		exec 'source '.phpcd_vim
-	endif
-
-	if exists('g:phpcd_channel_id')
-		call rpc#stop(g:phpcd_channel_id)
-
-		unlet g:phpcd_channel_id
-		if exists('g:phpid_channel_id')
-			unlet g:phpid_channel_id
-		endif
-	endif
-endfunction " }}}
-
-if (g:phpcd_auto_restart == 0 && g:phpcd_root == '/') || (g:phpcd_auto_restart == 1 && phpcd#GetRoot() != g:phpcd_root)
-	call Init()
-endif
-
-if !exists('g:phpcd_channel_id')
-	let phpcd_path = expand('<sfile>:p:h:h') . '/php/main.php'
-	let g:php_autoload_path = g:phpcd_root.'/'.g:phpcd_autoload_path
-	let g:phpcd_channel_id = rpc#start(g:phpcd_php_cli_executable,
-				\ phpcd_path, g:phpcd_root, messenger, g:php_autoload_path,
-				\ g:phpcd_disable_modifier)
-
-	if g:phpcd_root != '/'
-		let g:phpid_channel_id = g:phpcd_channel_id
-	endif
+if !g:phpcd_auto_restart
+	call phpcd#OpenFileNoAutoRestart()
 endif
 
 let &cpo = s:save_cpo

--- a/plugin/phpcd.vim
+++ b/plugin/phpcd.vim
@@ -5,12 +5,17 @@ let g:phpcd_root = '/'
 let g:phpcd_php_cli_executable = 'php'
 let g:phpcd_autoload_path = 'vendor/autoload.php'
 let g:phpcd_need_update = 0
-let g:phpcd_auto_restart = 0
 let g:phpcd_disable_modifier = 0
+if !exists('g:phpcd_auto_restart')
+	let g:phpcd_auto_restart = 0
+endif
 
 autocmd BufLeave,VimLeave *.php if g:phpcd_need_update > 0 | call phpcd#UpdateIndex() | endif
 autocmd BufWritePost *.php let g:phpcd_need_update = 1
 autocmd FileType php setlocal omnifunc=phpcd#CompletePHP
+if g:phpcd_auto_restart
+	autocmd FileType php autocmd BufEnter <buffer> call phpcd#EnterBufferWithAutoRestart()
+endif
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
To address issue #110, perform initialization in a BufEnter autocommand if g:phpcd_auto_restart is set to 1 (as requested in https://github.com/lvht/phpcd.vim/pull/111). If g:phpcd_auto_restart is set to the default value of 0, perform initialization when the ftplugin is loaded.