### PR TITLE
Don't clone vimunit or look for vimunit within phpcd directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /vendor/
 .*
-/vimunit
 composer.lock
 
 # Ignore deoplete source cache

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -4,19 +4,8 @@ set -eu
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-if [ -f "$DIR/../vimunit/vutest.sh" ]; then
-	# vimunit in the plugin root
-	VU="$DIR/../vimunit/vutest.sh"
-
-elif [ -f "$DIR/../../vimunit/vutest.sh" ]; then
-	# vimunit in the plugin root's parent dir (think of ~/.vim/bundle)
-	VU="$DIR/../../vimunit/vutest.sh"
-
-else
-	# no vimunit found, just grab it from github
-	git clone https://github.com/complex857/vimunit.git "$DIR/../vimunit"
-	VU="$DIR/../vimunit/vutest.sh"
-fi
+# vimunit in the plugin root's parent dir (think of ~/.vim/bundle)
+VU="$DIR/../../vimunit/vutest.sh"
 
 if [ ! -f "$VU" ]; then
 	echo "Could not run tests. Vimunit executeable not found at: '$VU'"

--- a/tests/vimrc
+++ b/tests/vimrc
@@ -3,4 +3,4 @@ syntax on
 set virtualedit+=onemore
 
 let p = fnamemodify(expand('%:p:h'), ':h')
-exe 'set rtp='.p.'/,'.p.'/vimunit/,'.p.'/../vimunit/,'.&rtp
+exe 'set rtp='.p.'/,'.p.'/../vimunit/,'.&rtp


### PR DESCRIPTION
Currently, if runtests.sh doesn't find vimunit, it clones complex857's fork of vimunit into /phpcd.vim/vimunit . I find that undesirable. After this commit, runtests.sh will look for vimunit only in (the equivalent of) ~/.vim/bundle/vimunit , and runtests.sh will just fail if it doesn't find vimunit. I think people who want to work on phpcd and run unit tests will be able to install vimunit themselves.