### PR TITLE
Parse error exception handling

### DIFF
--- a/autoload/phpcd.vim
+++ b/autoload/phpcd.vim
@@ -641,6 +641,10 @@ function! phpcd#GetClassName(start_line, context, current_namespace, imports) " 
 	let class_candidate_imports = a:imports
 	let methodstack = phpcd#GetMethodStack(a:context) " }}}
 
+	if empty(methodstack)
+		return ''
+	endif
+
 	if methodstack[-1] =~# '\vmake|app|get' " {{{
 		" just for laravel and container-interop
 		let container_interface = matchstr(methodstack[-1], '^\(make\|app\|get\)(\zs.\+\ze::class)')

--- a/autoload/phpcd.vim
+++ b/autoload/phpcd.vim
@@ -979,24 +979,32 @@ endfunction " }}}
 
 function! phpcd#GetCallChainReturnTypeAt(line) " {{{
 	silent! below 1sp
-	exec 'normal! ' . a:line . 'G'
-	call search(';')
-	let [_, context, namespace, imports] = phpcd#GetCurrentSymbolWithContext()
-	let classname = phpcd#GetClassName(line('.'), context, namespace, imports)
-	q
+	let classname = ''
+	try
+		exec 'normal! ' . a:line . 'G'
+		call search(';')
+		let [_, context, namespace, imports] = phpcd#GetCurrentSymbolWithContext()
+		let classname = phpcd#GetClassName(line('.'), context, namespace, imports)
+	finally
+		q
+	endtry
 	return classname
 endfunction " }}}
 
 function! phpcd#GetTypeAt(line, context) " {{{
 	silent! below 1sp
-	exec 'normal! ' . a:line . 'G'
-	call search(';')
-	normal beh
-	let [_, context, namespace, imports] = phpcd#GetCurrentSymbolWithContext()
-	let instruction = phpcd#GetCurrentInstruction(line('.'), col('.'), [0,0])
-	let context = instruction.a:context
-	let classname = phpcd#GetClassName(line('.'), context, namespace, imports)
-	q
+	let classname = ''
+	try
+		exec 'normal! ' . a:line . 'G'
+		call search(';')
+		normal beh
+		let [_, context, namespace, imports] = phpcd#GetCurrentSymbolWithContext()
+		let instruction = phpcd#GetCurrentInstruction(line('.'), col('.'), [0,0])
+		let context = instruction.a:context
+		let classname = phpcd#GetClassName(line('.'), context, namespace, imports)
+	finally
+		q
+	endtry
 	return classname
 endfunction " }}}
 

--- a/autoload/rpc.vim
+++ b/autoload/rpc.vim
@@ -37,7 +37,12 @@ function! s:OnCall(status, response) " {{{
 endfunction " }}}
 
 function! s:OnError(a, b, c) " {{{
-	echo join(a:b, "\n")
+	let msg = join(a:b, "\n")
+	if msg =~# '^PHP Parse' && len(a:b) > 1
+		let msg = a:b[1]
+	endif
+
+	echo substitute(msg, escape(getcwd() . '/', '.'), '', 'g')
 endfunction
 
 function! s:OnError2(a, b)


### PR DESCRIPTION
This fixes some annoying things that happens when a parse error is encountered.

Parse errors will display a duplicated error message like:

```
PHP Parse error: syntax error, unexpected 'public' (T_PUBLIC), expecting variable (T_VARIABLE) in /home/user/very/long/path/project/libxp/classes/lib/model/User.php on line 32
Parse error: syntax error, unexpected 'public' (T_PUBLIC), expecting variable (T_VARIABLE) in /home/user/very/long/path/project/libxp/classes/lib/model/User.php on line 32
```

It causes the command line to grow to **at least** 3 lines since it invokes the `more-prompt`.  After you press enter to clear the message, it leaves behind a 1 line window that has the cursor focus.