### PR TITLE
Improve runtests

### DIFF
--- a/autoload/phpcd.vim
+++ b/autoload/phpcd.vim
@@ -545,7 +545,7 @@ function! phpcd#GetCallChainReturnType(classname_candidate, class_candidate_name
 	endif " }}}
 
 	if (len(methodstack) == 1) " {{{
-		let [classname_candidate, class_candidate_namespace] = phpcd#ExpandClassName(classname_candidate, class_candidate_namespace, imports)
+		"let [classname_candidate, class_candidate_namespace] = phpcd#ExpandClassName(classname_candidate, class_candidate_namespace, imports)
 		let return_type = s:GetFullName(class_candidate_namespace, classname_candidate)
 
 		return return_type

--- a/php/ClassNameVisitor.php
+++ b/php/ClassNameVisitor.php
@@ -7,12 +7,18 @@ use PhpParser\NodeTraverser;
 
 class ClassNameVisitor extends NodeVisitorAbstract
 {
+	/**
+	 * contains full namespaced classname after leaveNode
+	 *
+	 * @var string
+	 */
     public $name;
 
     public function leaveNode(Node $node)
     {
+		$this->name = null;
         if ($node instanceof Node\Stmt\Class_ && isset($node->namespacedName)) {
-            $this->class = (string)$node->namespacedName;
+            $this->name = (string)$node->namespacedName;
             return NodeTraverser::STOP_TRAVERSAL;
         }
     }

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -11,12 +11,38 @@ declare -a TESTSTORUN
 
 set -eu
 
+#by default we rebuild phpcds index every-time
+REBUILDIDX=1
+
 function help(){
 	echo "USAGE: runtests.sh[ options][ list of tests]"
 	echo ""
 	echo "-e    vim-executeable e.g. vim nvim etc"
+	echo "-n    do not recreate phpcds index if exist"
 	echo "-h|--help|-?    prints this help"
 } 
+
+function recreateIndex(){
+	#delete and rebuild the index
+	#we do this because changes on the code can affect the contents of the index
+	if [ -d $DIR/fixtures/.phpcd ]; then
+		if [ 1 -ne $REBUILDIDX ]; then
+			#rebuild of index disabled by user
+			return;
+		fi
+		rm -r $DIR/fixtures/.phpcd
+	fi
+	OLDPWD=$(pwd)
+	cd $DIR/fixtures
+	#@TODO find a better and more secure alternative for the 2sleep
+	$VIM -c "call phpcd#Index() | 2sleep | quit" ./PHPCD/SameName/A/Same.php
+	if [ ! -f $DIR/fixtures/.phpcd/extends/PHPCD_SameName_A_SuperSame.json ]
+	then
+		echo -e "\033[31mRebuilding PHPCD's index failed!\033[0m"
+		exit 2
+	fi
+	cd $OLDPWD
+}
 
 function setVim(){
 	if [[ -n ${VIM+x} ]]; then
@@ -54,6 +80,9 @@ while [ 0 -lt $# ]; do
       help
 	  exit 0
       ;;
+	'-n' )
+		REBUILDIDX=0
+	;;
 	*)
 		if [[ "$1" =~ "^-" ]]; then
 			echo -e "\033[31mUnknow parameter \"$1\"\033[0m"
@@ -76,6 +105,9 @@ if [ ! -f "$VU" ]; then
 	echo -e "\033[31mCould not run tests. Vimunit executeable not found at: '$VU'\033[0m"
 	exit 1
 fi
+
+
+recreateIndex
 
 if [[ ${TESTSTORUN[@]} ]]; then
 	#run tests given as param

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,24 +1,91 @@
 #! /usr/bin/env bash
+#
+#Script to run all unit-tests of phpcd
+#
+#Script dependencies:
+#bash-version 4.4 or above
+#vimunit installed parallel to phpcds install dir
+#for vimunit see dsummersl/vimunit on github
+
+declare -a TESTSTORUN
 
 set -eu
+
+function help(){
+	echo "USAGE: runtests.sh[ options][ list of tests]"
+	echo ""
+	echo "-e    vim-executeable e.g. vim nvim etc"
+	echo "-h|--help|-?    prints this help"
+} 
+
+function setVim(){
+	if [[ -n ${VIM+x} ]]; then
+		#script called with -e
+			VIM=$(which $VIM)
+	else
+		#first look for nvim
+		#nvim was used in earlier version, try to keep backward compatible
+		VIM=$(which nvim)
+		if [ 0 -ne $? ]; then
+			#nvim not found, look for vim.nox
+			VIM=$(which vim.nox)
+			if [ 0 -ne $? ]; then
+				VIM=$(which vim)
+			fi
+		fi
+	fi
+
+	if [ -z $VIM ] || [ ! -x $VIM ]; then
+		echo -e "\033[31mNo vim executable found or given!\033[0m"
+		exit 1
+	fi
+}
+while [ 0 -lt $# ]; do
+	case "$1" in
+	'-e' )
+		shift
+		if [ 0 -eq $# ]; then
+			echo -e "\033[31m-e musst be followed by a vim like program!\033[0m"
+			exit 4
+		fi
+		VIM="$1"
+      ;;
+	'--help'|'-h'|'-?')
+      help
+	  exit 0
+      ;;
+	*)
+		if [[ "$1" =~ "^-" ]]; then
+			echo -e "\033[31mUnknow parameter \"$1\"\033[0m"
+			help
+			exit 3
+		fi
+		TESTSTORUN+=("$1")
+  esac
+  shift
+done
+
+setVim
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # vimunit in the plugin root's parent dir (think of ~/.vim/bundle)
-VU="$DIR/../../vimunit/vutest.sh"
+VU="$(dirname $(dirname $DIR))/vimunit/vutest.sh"
 
 if [ ! -f "$VU" ]; then
-	echo "Could not run tests. Vimunit executeable not found at: '$VU'"
+	echo -e "\033[31mCould not run tests. Vimunit executeable not found at: '$VU'\033[0m"
+	exit 1
+fi
+
+if [[ ${TESTSTORUN[@]} ]]; then
+	#run tests given as param
+	cnt=${#TESTSTORUN[*]}
+	for ((i = 0; i < $cnt; i++)); do
+		$VU "-e $VIM -u $DIR/vimrc" ${TESTSTORUN[$i]}
+	done
 else
-    cd $DIR/fixtures
-    if [[ $# > 0 ]]; then
-        for f in $@; do
-            $VU -e "nvim -u $DIR/vimrc" $f
-        done
-    else
-        for f in "$DIR/"*.vim; do
-		echo $DIR
-            $VU -e "nvim -u $DIR/vimrc" $f
-        done
-    fi
+	#run all tests
+	for f in "$DIR/"*.vim; do
+		$VU "-e $VIM -u $DIR/vimrc" $f
+	done
 fi

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
 set -eu
 
@@ -10,7 +10,7 @@ VU="$DIR/../../vimunit/vutest.sh"
 if [ ! -f "$VU" ]; then
 	echo "Could not run tests. Vimunit executeable not found at: '$VU'"
 else
-    cd ./fixtures
+    cd $DIR/fixtures
     if [[ $# > 0 ]]; then
         for f in $@; do
             $VU -e "nvim -u $DIR/vimrc" $f

--- a/tests/vimrc
+++ b/tests/vimrc
@@ -2,5 +2,13 @@ filetype plugin indent on
 syntax on
 set virtualedit+=onemore
 
+"vimunit uses a lot of line-continuations which vim 8.0 only likes is 
+"nocompatible mode
+"see https://stackoverflow.com/questions/6696079/vimrc-causes-error-e10-should-be-followed-by-or/6696615
+set nocompatible
+
+"vimunit seems to have problems if the language is not setted to English
+language C.UTF-8
+
 let p = fnamemodify(expand('%:p:h'), ':h')
 exe 'set rtp='.p.'/,'.p.'/../vimunit/,'.&rtp


### PR DESCRIPTION
Hello!

First of all, thank you for your work.
I like phpcd very much and it's very usefull.

I've made some improvements to runscript.sh (at least, I hope so).
The main diffrence is the possiblity to choose a another vim executeable by the “-e” param and the automated rebuilding of the index for the tests.

However, I found two mistakes in the regular code of phpcd.
The first broke the building of the index.
(please see my changes to ClassNameVisitor.php) 
This is the one I'm a bit surprised about.
Is phpcd#Index() no longer in use?
Otherwise, I wonder why no one else is having this problem.

The second change, is the one to the file phpcd.vim.
The code is processed twice at the point of change.
The correct result is present after the first visit.
Please have a double check to this change in case you will accept my pull request.
I'm not 100% sure that the change is not having any side effects.

A note to vimunit. There is a problem with vimunit on more recent versions of vim than 8.0.707. I have also created a pull request for vimunit, but unfortuneatelly it has not been accepted yet.


Best regards!

trlt
