### PR TITLE
Fix "ModuleNotFoundError: No module named 'neovim.api.nvim'"

### DIFF
--- a/rplugin/python3/deoplete/sources/phpcd.py
+++ b/rplugin/python3/deoplete/sources/phpcd.py
@@ -1,5 +1,5 @@
 from .base import Base
-from neovim.api.nvim import NvimError
+from pynvim.api.nvim import NvimError
 
 class Source(Base):
     def __init__(self, vim):


### PR DESCRIPTION
neovim for python has been renamed to pynvim