### PR TITLE
PrefixMatcher: perform case-insensitive search

### DIFF
--- a/php/Matcher/PrefixMatcher.php
+++ b/php/Matcher/PrefixMatcher.php
@@ -9,6 +9,6 @@ class PrefixMatcher implements Matcher
             return true;
         }
 
-        return substr($target, 0, strlen($pattern)) === $pattern;
+        return preg_match('/^' . preg_quote($pattern, '/') . '/i', $target);
     }
 }


### PR DESCRIPTION
Hi, since PHP is a case-insensitive language, it would be useful to also perform the matches this way.