### PR TITLE
cast $alias to string

### DIFF
--- a/php/ClassNameExVisitor.php
+++ b/php/ClassNameExVisitor.php
@@ -42,7 +42,7 @@ class ClassNameExVisitor extends NodeVisitorAbstract
                 }
 
                 if ($use->type !== Node\Stmt\Use_::TYPE_CONSTANT) {
-                    $this->imports[$alias] = (string)$use->name;
+                    $this->imports[(string)$alias] = (string)$use->name;
                 }
             }
         }


### PR DESCRIPTION
The variable $alias as an array offset being object of type PhpParser\Node\Identifier caused it throwing exception and stop further travarsals, so I added string cast so that it can take use statements with alias.